### PR TITLE
chore: upgrade MariaDB from 11.4 to 11.8

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -8,7 +8,7 @@ additional_hostnames: []
 additional_fqdns: []
 database:
     type: mariadb
-    version: "11.4"
+    version: "11.8"
 use_dns_when_possible: true
 composer_version: "2"
 web_environment: []


### PR DESCRIPTION
## Summary
This PR upgrades MariaDB from version 11.4 to 11.8.

## Changes
- Updated database version in `.ddev/config.yaml` to MariaDB 11.8

## Rationale
- MariaDB 11.8.4 is the current stable release ([MariaDB announcement](https://mariadb.org/mariadb-11-8-4-11-4-9-10-11-15-and-10-6-24-now-available/))
- DDEV fully supports MariaDB 11.8 as per [official documentation](https://docs.ddev.com/en/stable/users/extend/database-types/)

## Testing
- Verified that DDEV starts correctly with MariaDB 11.8
- No breaking changes expected as it's a minor version bump